### PR TITLE
New Feature: Expand and Collapse Animation to Routes

### DIFF
--- a/src/Components/Route.js
+++ b/src/Components/Route.js
@@ -2,8 +2,15 @@ import "../styles/Route.css";
 
 import Step from "./Step";
 
+import {useState} from 'react';
 
 export default function Route(props) {
+    // --- USE STATES ----
+    // isExpanded:
+    //           If "true" -> the route__steps-list section is expanded
+    //           If "no"   -> the route__steps-list section is collapsed 
+    const [isExpanded ,setIsExpanded] = useState(true) 
+
     // --------------------------------------------------------
     // --------------------------------------------------------
     // ---- HANDELERS ----
@@ -20,6 +27,14 @@ export default function Route(props) {
     // DESCRIPTION: Removes a route from the routesList
     const handleRemoveRoute = () => {
         props.removeRoute(props.routeIndex)
+    }
+
+    // DESCRIPTION: Expands\Collapses the route__steps-list section, and updates the state accordingly
+    const handleExpandAndCollapse = () => {
+        setIsExpanded((currIsExpanded) => !currIsExpanded)
+
+        const divStepList = document.getElementsByClassName("route__steps-list")[props.routeIndex]
+        divStepList.classList.toggle('hidden')
     }
     // --------------------------------------------------------
     // --------------------------------------------------------
@@ -65,7 +80,7 @@ export default function Route(props) {
                             <button className="route__button--remove-selected">Remove Selected</button> {/* TODO: Add functionality to this button */}
                         </div>
                     </div>
-                    <button className="route__button--expand-collapse">Expand/Collapse</button> {/* TODO: Add functionality to this button */}
+                    <button className="route__button--expand-collapse" onClick={handleExpandAndCollapse}>{isExpanded ? <span>Collapse</span> : <span>Expand</span>}</button> 
                 </div>
                 <section className="route__steps-list">
                     {stepsListJSX}

--- a/src/styles/Route.css
+++ b/src/styles/Route.css
@@ -1,7 +1,6 @@
 .route {
     background-color: lightgray;
     width: 100%;
-    /* min-height: 6rem; 15%; */
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -74,11 +73,17 @@
 
 .route__steps-list {
     width: 100%;
-    
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
     align-items: center;
-    overflow: visible;
     overflow-x: hidden;
+    overflow: hidden;
+
+    max-height: 4000px; /* hard setting the max-heigth to be 4000px -> approx. enough place for 100 steps per route (assuming no-one will ever make it...) */
+    transition: max-height 0.8s ease-in-out; 
+}
+
+.hidden {
+    max-height: 0;
 }

--- a/src/styles/Route.css
+++ b/src/styles/Route.css
@@ -81,9 +81,10 @@
     overflow: hidden;
 
     max-height: 4000px; /* hard setting the max-heigth to be 4000px -> approx. enough place for 100 steps per route (assuming no-one will ever make it...) */
-    transition: max-height 0.8s ease-in-out; 
+    transition: max-height 0.8s ease-in-out; /* expand animation */
 }
 
 .hidden {
-    max-height: 0;
+    max-height: 0; /* when clicking on expand, the expand animation will start till max-height: 0 */
+    transition: max-height 0.2s ease-in-out; /* collapse animation -> a little faster animation */
 }


### PR DESCRIPTION
## Show Case:
Introduce a new functionality that allows users to expand and collapse routes sizes by clicking on the "Expand\Collapse" button.
This feature would streamline the entering data process for users who are dealing with complex route structures and help them focus on the relevant sections.

## Current Problem:
- We are hard setting the max-height , which limits the user in the amount of steps per route he can add

## Preferred Solution (according to priority)
- Avoiding hard setting completely
OR
- To use vh values for hard setting instead of px 
OR
- Using only expand and collapse logic without the animation

### Linked Issue:
- #10 
