### PR TITLE
Feat: adding a Multiple-expansion feature

### DIFF
--- a/src/Components/Route.js
+++ b/src/Components/Route.js
@@ -92,7 +92,12 @@ export default function Route(props) {
     // DESCRIPTION: Expands\Collapses the route__steps-list section, and updates the state accordingly
     const handleExpandAndCollapse = () => {
         const divStepList = document.getElementsByClassName("route__steps-list")[props.routeIndex]
-        props.expandAndCollapse(props.routeElement, divStepList, props.routeIndex)
+        if (props.routeElement.isExpanded) {
+            props.setIsExpandedFalse(props.routeIndex)
+        }
+        else {
+            props.setIsExpandedTrue(props.routeIndex)
+        }
     }
     // --------------------------------------------------------
     // --------------------------------------------------------
@@ -169,13 +174,13 @@ export default function Route(props) {
                             <button className="route__button--remove-selected" onClick={handleRemoveSelectedSteps}>Remove Selected Steps</button>
                         </div>
                     </div>
-                    {props.routeElement.stepList.length !== 0 ?
-                        <IconButton onClick={handleExpandAndCollapse} className="route__button--expand-collapse">
-                            {props.isExpanded ? <ExpandLessIcon className="route__expand-collapse-icon" /> : <ExpandMoreIcon className="route__expand-collapse-icon" />}
-                        </IconButton> : null
-                    }
+
+                    <IconButton onClick={handleExpandAndCollapse} className="route__button--expand-collapse" disabled={props.routeElement.stepList.length == 0}>
+                        {props.routeElement.isExpanded ? <ExpandLessIcon className="route__expand-collapse-icon" /> : <ExpandMoreIcon className="route__expand-collapse-icon" />}
+                    </IconButton>
+
                 </div>
-                <section className={props.isExpanded ? "route__steps-list" : "route__steps-list hidden"}>
+                <section className={props.routeElement.isExpanded ? "route__steps-list" : "route__steps-list hidden"}>
                     {stepsListJSX}
                 </section>
             </div>

--- a/src/Components/RouteEditor.js
+++ b/src/Components/RouteEditor.js
@@ -22,28 +22,9 @@ export default function RouteEditor({ routesList, setRoutesList }) {
     // warningMessageJSX: The JSX of the warning message that will be displayed to the user when he tries to remove selected routes
     const [warningMessageJSX, setWarningMessageJSX] = useState(null);
 
-    // expandedIndex:
-    //              Defines the route that will be extended from all the routes
-    //              Only one route will be extended at a time
-    const [expandedIndex, setExpandedIndex] = useState(-1)
-    // --------------------------------------------------------
-    // --------------------------------------------------------
-
-
     // --------------------------------------------------------
     // --------------------------------------------------------
     // ----- CHECK BOX LOGIC HELPER CALLBACKS ------
-
-
-    // DESCRIPTION: Enters the routeElement, divStepList (the expanded step list element) and routeIndex
-    // Will Expands\Collapses and updates the state accordingly
-    const expandAndCollapse = (routeElement, divStepList, routeIndex) => {
-        setExpandedIndex(-1)
-        if (routeElement.stepList.length !== 0 && routeIndex !== expandedIndex) {
-            setExpandedIndex(routeIndex)
-        }
-    }
-
 
     // DESCRIPTION: Enters the updated checked value of the route, and updates the state accordingly
     const updateCheckedRoute = (checkedValue, routeIndex) => {
@@ -92,6 +73,33 @@ export default function RouteEditor({ routesList, setRoutesList }) {
     // ----- UPDATE DATA HELPER CALLBACKS ------
 
 
+    // DESCRIPTION: Set the 'IsExpanded' value of the route with the appropriate index to true
+    // To determine that the route is in extended mode
+    const setIsExpandedTrue = (routeIndex) => {
+        setRoutesList(currRouteList => {
+            return currRouteList.map((currRoute, currRouteIndex) => {
+                if (currRouteIndex === routeIndex && currRoute.stepList.length !== 0)
+                    return { ...currRoute, isExpanded: true }
+                else
+                    return currRoute
+            })
+        });
+    }
+
+    // DESCRIPTION: Set the 'IsExpanded' value of the route with the appropriate index to false
+    // To determine that the route is not in extended mode
+    // When routeIndex = -1, Go through all routes, the route with an empty stepList will be UnExpanded
+    const setIsExpandedFalse = (routeIndex = -1) => {
+        setRoutesList(currRouteList => {
+            return currRouteList.map((currRoute, currRouteIndex) => {
+                if (currRouteIndex === routeIndex || currRoute.stepList.length === 0)
+                    return { ...currRoute, isExpanded: false }
+                else
+                    return currRoute
+            })
+        });
+    }
+
     // DESCRIPTION: Enters the new name of the route with the appropriate index, and updates the state accordingly
     const addRouteNameToRoute = (routeName, routeIndex) => {
         setRoutesList(currRouteList => {
@@ -114,7 +122,7 @@ export default function RouteEditor({ routesList, setRoutesList }) {
                     return currRoute
             })
         });
-        setExpandedIndex(routeIndex);
+        setIsExpandedTrue(routeIndex);
     }
 
     // DESCRIPTION: Enters the updated length of the step with the appropriate index that inside the route with the appropriate index, and updates the state accordingly
@@ -165,7 +173,7 @@ export default function RouteEditor({ routesList, setRoutesList }) {
 
     // DESCRIPTION: Adds a new route to the routesList
     const handleNewRouteInput = () => {
-        setRoutesList((currRouteList) => [...currRouteList, { routeName: "", stepList: [], isChecked: isSelectedAll }])
+        setRoutesList((currRouteList) => [...currRouteList, { routeName: "", stepList: [], isChecked: isSelectedAll, isExpanded: false }])
     }
     // --------------------------------------------------------
     // --------------------------------------------------------
@@ -185,12 +193,6 @@ export default function RouteEditor({ routesList, setRoutesList }) {
                     return true
             })
         });
-        if (routeIndex < expandedIndex) {
-            setExpandedIndex(expandedIndex - 1);
-        }
-        else if (routeIndex === expandedIndex) {
-            setExpandedIndex(-1);
-        }
     }
 
     const removeSelectedRoutes = () => {
@@ -233,11 +235,7 @@ export default function RouteEditor({ routesList, setRoutesList }) {
                 return currRoute;
             });
         });
-        routesList.forEach((currRoute, currRouteIndex) => {
-            if (currRoute.stepList.length === 0 && currRouteIndex === routeIndex) {
-                setExpandedIndex(-1);
-            }
-        })
+        setIsExpandedFalse();
     }
 
     // DESCRIPTION: Removes the selected steps from the stepList of the route with the appropriate index
@@ -251,6 +249,7 @@ export default function RouteEditor({ routesList, setRoutesList }) {
                 else return currRoute
             })
         })
+        setIsExpandedFalse();
     }
     // --------------------------------------------------------
     // --------------------------------------------------------
@@ -270,7 +269,8 @@ export default function RouteEditor({ routesList, setRoutesList }) {
         routesList.forEach((route, index) => {
             console.log(`Route #${index + 1}: `);
             console.log(`       Route Name: ${route.routeName}`);
-            console.log(`       Checked Status: ${route.isChecked}`)
+            console.log(`       Checked Status: ${route.isChecked}`);
+            console.log(`       Checked IsExpanded: ${route.isExpanded}`);
             console.log(`       Step List: `);
             if (route.stepList.length === 0) {
                 console.log("           The stepList is empty!!!");
@@ -281,10 +281,10 @@ export default function RouteEditor({ routesList, setRoutesList }) {
                 console.log(`           Step #${index + 1}: `);
                 console.log(`                   Step List Length: ${step.length}`);
                 console.log(`                   Step List Direction: ${step.direction}`);
-                console.log(`                   Step List Checked Status: ${step.isChecked}`)
+                console.log(`                   Step List Checked Status: ${step.isChecked}`);
             });
         });
-        console.log("-------------------------------------------------------------")
+        console.log("-------------------------------------------------------------");
     }
     // --------------------------------------------------------
     // --------------------------------------------------------
@@ -327,8 +327,8 @@ export default function RouteEditor({ routesList, setRoutesList }) {
         // 9. routeElement -> Sending a read-only ref of the current routeElement.
         // 10. updateCheckedRoute -> Sending a callback to *update data about route's checkbox status*
         // 11. updateCheckedStep -> Sending a callback to *update data about step's checkbox status* from specific route
-        // 12. isExpanded -> Sending a read-only ref of the current expandedIndex.
-        // 13. expandAndCollapse -> Sending a callback to *set the expanded route via the Index*
+        // 12. setIsExpandedTrue -> Sending a callback to *set the 'isExpanded' value to true*
+        // 13. setIsExpandedFalse -> Sending a callback to *set the 'isExpanded' value to false*
 
         <Route key={index}
             routeIndex={index}
@@ -342,8 +342,9 @@ export default function RouteEditor({ routesList, setRoutesList }) {
             routeElement={routeElement}
             updateCheckedRoute={updateCheckedRoute}
             updateCheckedStep={updateCheckedStep}
-            isExpanded={expandedIndex === index}
-            expandAndCollapse={expandAndCollapse} />
+            setIsExpandedTrue={setIsExpandedTrue}
+            setIsExpandedFalse={setIsExpandedFalse}
+        />
     ));
     // --------------------------------------------------------
 

--- a/src/styles/Route.css
+++ b/src/styles/Route.css
@@ -36,7 +36,7 @@
     display: grid;
     grid-template-columns: 60% 30%;
     column-gap: 10%;
-    
+
 }
 
 .route__name {
@@ -45,10 +45,10 @@
     place-items: center;
 }
 
-.route__name > input {
+.route__name>input {
     width: 100%;
     height: 80%;
-    
+
     font-size: 1.9rem;
 }
 
@@ -60,7 +60,7 @@
     height: 100%;
 }
 
-.route__buttons > button {
+.route__buttons>button {
     width: 100%;
     height: 100%;
 }
@@ -71,8 +71,15 @@
     border-left: black 1px solid;*/
 }
 
-.route__expand-collapse-icon{
+.route__button--expand-collapse:disabled>.route__expand-collapse-icon {
+    color: #777777;
+    border: none;
+}
+
+.route__expand-collapse-icon {
     color: black;
+    border: 2px solid #525252;
+    border-radius: 7px;
 }
 
 .route__steps-list {
@@ -84,11 +91,15 @@
     overflow-x: hidden;
     overflow: hidden;
 
-    max-height: 4000px; /* hard setting the max-heigth to be 4000px -> approx. enough place for 100 steps per route (assuming no-one will ever make it...) */
-    transition: max-height 0.8s ease-in-out; /* expand animation */
+    max-height: 4000px;
+    /* hard setting the max-heigth to be 4000px -> approx. enough place for 100 steps per route (assuming no-one will ever make it...) */
+    transition: max-height 0.8s ease-in-out;
+    /* expand animation */
 }
 
 .hidden {
-    max-height: 0; /* when clicking on expand, the expand animation will start till max-height: 0 */
-    transition: max-height 0.2s ease-in-out; /* collapse animation -> a little faster animation */
+    max-height: 0;
+    /* when clicking on expand, the expand animation will start till max-height: 0 */
+    transition: max-height 0.2s ease-in-out;
+    /* collapse animation -> a little faster animation */
 }


### PR DESCRIPTION
# Description
in the current version only one Route can be expanded at a time.
for more user friendly experience, we need to add the 'Multiple expansion' Feature
So that the user will not be limited in the amount of expanded routes

## implementation:

- Creating a Boolean property `isExpanded` inside the `route` object that indicates when that route is in expanded state
rather than being based on a single index that determines which route is Expanded

- Additionally changing the `expand-collapse-icon` to be disabled when necessary
along with changing the style of the icon in its normal state, and in its disabled state


This is the implementation of issue #19 
